### PR TITLE
Generate nbviewer links for impacted notebooks

### DIFF
--- a/.github/workflows/nbviewer.yml
+++ b/.github/workflows/nbviewer.yml
@@ -1,0 +1,45 @@
+name: generate nbviewer links
+on:
+  pull_request:
+    types: [opened, edited]
+    branches:
+      - main
+    paths:
+      - "**.ipynb"
+
+jobs:
+  nbviewer-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: get files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+
+      - name: add comments
+        uses: actions/github-script@v3
+        env:
+          FILES: ${{steps.files.outputs.all}}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          debug: true
+          script: |
+            console.log(process.env)
+
+            const body = process.env.FILES
+              .split(" ")
+              .filter(f => f.endsWith(".ipynb"))
+              .map(f => `* [${f}](https://nbviewer.jupyter.org/github/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${f})`)
+
+            if (body.length > 0) {
+              github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "nbviewer URLs for impacted notebooks:\n\n" + body.join("\n")
+              })
+            }

--- a/.github/workflows/nbviewer.yml
+++ b/.github/workflows/nbviewer.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            console.log(process.env)
-
             const body = process.env.FILES
               .split(" ")
               .filter(f => f.endsWith(".ipynb"))

--- a/.github/workflows/nbviewer.yml
+++ b/.github/workflows/nbviewer.yml
@@ -26,7 +26,6 @@ jobs:
           FILES: ${{steps.files.outputs.all}}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          debug: true
           script: |
             console.log(process.env)
 


### PR DESCRIPTION
GitHub action fires on PR open and update, if the impacted file paths contain a `*.ipynb`. Posts a comment with an nbviewer link for each impacted notebook in the PR. 

Here's an example from my fork: https://github.com/thekaveman/notebooks/pull/1#issuecomment-822645150