### PR TITLE
[WIP] add notebook to download validator notices for districts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,11 @@ WORKDIR "/app"
 
 COPY . /app
 
-CMD ["voila","--port=8080","--no-browser","--show_tracebacks=True"] 
+ 
+# Note that using linebreaks with CMD appears impossible when using []
+# see https://stackoverflow.com/q/46469821/1144523
+CMD voila \
+     --port=8080 --no-browser --show_tracebacks=True \
+     --VoilaConfiguration.file_whitelist="['.*\.(png|jpg|gif|svg|mp4|avi|ogg|csv)']" \
+     --TagRemovePreprocessor.remove_cell_tags hide \
+     --TagRemovePreprocessor.remove_cell_tags dummy-hide

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
     container_name: jupyter-lab
     volumes:
      - ./:/app
+     - $HOME/.config/gcloud:/home/jovyan/.config/gcloud
     ports:
-      - "8888:8888"
+      - "8889:8888"
     environment:
       - DEV=1
       - POSTGRES_URI=postgres://caltrans:secret@postgres:5432/caltrans
@@ -19,6 +20,7 @@ services:
     container_name: voila
     volumes:
      - ./:/app
+     - $HOME/.config/gcloud:/home/jovyan/.config/gcloud
     ports:
       - "8080:8080"
   postgres:

--- a/notebooks/download_validation_notices.ipynb
+++ b/notebooks/download_validation_notices.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from siuba.sql import LazyTbl\n",
+    "from siuba import *\n",
+    "from sqlalchemy import create_engine\n",
+    "import pandas as pd\n",
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import interact\n",
+    "\n",
+    "from IPython.display import display, FileLink"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = create_engine(\"bigquery://cal-itp-data-infra\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbl_status = LazyTbl(engine, \"gtfs_schedule.calitp_status\")\n",
+    "tbl_validation_notices = LazyTbl(engine, 'test_views.validation_notices')\n",
+    "sheet = pd.read_csv(\"https://docs.google.com/spreadsheets/d/105oar4q_Z3yihDeUlP-VnYpJ0N9Mfs7-q4TnribqYLU/gviz/tq?tqx=out:csv&gid=471807468\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetch district specific validator results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "options = sheet[\"Caltrans District\"].dropna().sort_values().astype(int).unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_district_validations(district):\n",
+    "    district = sheet[lambda d: d[\"Caltrans District\"] == district]\n",
+    "    itp_ids = district.ITP_ID.astype(int).tolist()\n",
+    "\n",
+    "    itp_id_str = \", \".join(map(str, itp_ids))\n",
+    "\n",
+    "    tbl_notices_subset = (\n",
+    "        tbl_validation_notices\n",
+    "        >> filter(_.calitp_itp_id.isin(itp_ids))\n",
+    "        >> left_join(\n",
+    "            _,\n",
+    "            tbl_status >> select(_.itp_id, _.url_number, _.agency_name),\n",
+    "            {\"calitp_itp_id\": \"itp_id\", \"calitp_url_number\": \"url_number\"},\n",
+    "        )\n",
+    "        # move useful columns to the left\n",
+    "        >> select(_.calitp_itp_id, _.calitp_url_number, _.agency_name, _.contains(\"\"))\n",
+    "    )\n",
+    "    \n",
+    "    return tbl_notices_subset >> collect()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b814d7cc17c34ef880fc7184c4faab0d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='district', options=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), value=…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "@interact(district=options)\n",
+    "def ui_download_validations(district):\n",
+    "    print(\"getting results...\")\n",
+    "    df = get_district_validations(district)\n",
+    "    \n",
+    "    fname = \"./district_%s_validations.csv\" % int(district)\n",
+    "    df.to_csv(fname)\n",
+    "    return FileLink(fname, result_html_prefix=\"Download file: \")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv-notebooks",
+   "language": "python",
+   "name": "venv-notebooks"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/download_validation_notices.ipynb
+++ b/notebooks/download_validation_notices.ipynb
@@ -2,26 +2,36 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "source": [
     "## Setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# analytics ----\n",
     "from siuba.sql import LazyTbl\n",
     "from siuba import *\n",
     "from sqlalchemy import create_engine\n",
     "import pandas as pd\n",
     "\n",
+    "# widgets ----\n",
     "import ipywidgets as widgets\n",
     "from ipywidgets import interact\n",
+    "from IPython.display import display, FileLink\n",
     "\n",
-    "from IPython.display import display, FileLink"
+    "# warnings ----\n",
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -35,16 +45,37 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide"
+    ]
+   },
    "source": [
     "## Create tables"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.9/site-packages/google/cloud/bigquery/client.py:461: UserWarning: Cannot create BigQuery Storage client, the dependency google-cloud-bigquery-storage is not installed.\n",
+      "  warnings.warn(\n",
+      "/opt/conda/lib/python3.9/site-packages/pybigquery/sqlalchemy_bigquery.py:524: SAWarning: Did not recognize type 'BIGNUMERIC' of column 'shapeDistTraveled'\n",
+      "  util.warn(\n",
+      "/opt/conda/lib/python3.9/site-packages/pybigquery/sqlalchemy_bigquery.py:524: SAWarning: Did not recognize type 'BIGNUMERIC' of column 'prevShapeDistTraveled'\n",
+      "  util.warn(\n",
+      "/opt/conda/lib/python3.9/site-packages/pybigquery/sqlalchemy_bigquery.py:524: SAWarning: Did not recognize type 'BIGNUMERIC' of column 'prevStopTimeDistTraveled'\n",
+      "  util.warn(\n",
+      "/opt/conda/lib/python3.9/site-packages/pybigquery/sqlalchemy_bigquery.py:524: SAWarning: Did not recognize type 'BIGNUMERIC' of column 'speedkmh'\n",
+      "  util.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "tbl_status = LazyTbl(engine, \"gtfs_schedule.calitp_status\")\n",
     "tbl_validation_notices = LazyTbl(engine, 'test_views.validation_notices')\n",
@@ -60,22 +91,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "options = sheet[\"Caltrans District\"].dropna().sort_values().astype(int).unique()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_district_validations(district):\n",
-    "    district = sheet[lambda d: d[\"Caltrans District\"] == district]\n",
-    "    itp_ids = district.ITP_ID.astype(int).tolist()\n",
+    "def get_district_validations(district, agency_itp_id=None):\n",
+    "    if agency_itp_id is None:\n",
+    "        df_district = sheet[lambda d: d[\"Caltrans District\"] == district]\n",
+    "        itp_ids = df_district.ITP_ID.astype(int).tolist()\n",
+    "    else:\n",
+    "        itp_ids = [agency_itp_id]\n",
     "\n",
     "    itp_id_str = \", \".join(map(str, itp_ids))\n",
     "\n",
@@ -96,18 +121,112 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ui_download_validations(district, agency, output):\n",
+    "    with output:\n",
+    "        if district is None:\n",
+    "            print(\"Select a district to download\")\n",
+    "            return\n",
+    "\n",
+    "        display(\"getting results...\")\n",
+    "        df = get_district_validations(district)\n",
+    "\n",
+    "        fname = \"./district_%s_validations.csv\" % int(district)\n",
+    "        df.to_csv(fname)\n",
+    "        \n",
+    "        display(FileLink(fname, result_html_prefix=\"Download file: \"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "options = sheet[\"Caltrans District\"].dropna().sort_values().astype(int).unique()\n",
+    "\n",
+    "w_district = widgets.Dropdown(options = [None, *options])\n",
+    "w_agency = widgets.Dropdown()\n",
+    "w_run = widgets.Button(description=\"Run\")\n",
+    "w_out = widgets.Output()\n",
+    "\n",
+    "\n",
+    "def update_agency(change):\n",
+    "    df_district = sheet[sheet[\"Caltrans District\"] == w_district.value]\n",
+    "    agency_ids = df_district.sort_values(\"Agency\")[[\"Agency\", \"ITP_ID\"]].dropna()\n",
+    "    \n",
+    "    itp_ids = agency_ids[\"ITP_ID\"].astype(int)\n",
+    "    agencies = agency_ids[\"Agency\"]\n",
+    "    \n",
+    "    w_agency.options = [(\"All agencies\", None), *zip(agencies, itp_ids)]\n",
+    "    w_agency.index = 0\n",
+    "\n",
+    "w_district.observe(update_agency, \"value\")\n",
+    "\n",
+    "w_run.on_click(\n",
+    "    lambda btn: ui_download_validations(w_district.value, w_agency.value, w_out)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b814d7cc17c34ef880fc7184c4faab0d",
+       "model_id": "85643c3625694981acf3cd67b6d48ae5",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "interactive(children=(Dropdown(description='district', options=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), value=…"
+       "Dropdown(options=(None, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), value=None)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4d048e0cea4644388ebc73126c4be1d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(options=(), value=None)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e63a4d4dd1e4094955187f62721ad8a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Run', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "161986b30ae84b1ea1923c319b2be332",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
       ]
      },
      "metadata": {},
@@ -115,14 +234,7 @@
     }
    ],
    "source": [
-    "@interact(district=options)\n",
-    "def ui_download_validations(district):\n",
-    "    print(\"getting results...\")\n",
-    "    df = get_district_validations(district)\n",
-    "    \n",
-    "    fname = \"./district_%s_validations.csv\" % int(district)\n",
-    "    df.to_csv(fname)\n",
-    "    return FileLink(fname, result_html_prefix=\"Download file: \")"
+    "display(w_district, w_agency, w_run, w_out)"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,6 @@ tqdm
 gcsfs
 ipyleaflet
 asyncio
-
+sqlalchemy~=1.3.0
+git+https://github.com/machow/siuba.git@feat-bigquery
+git+https://github.com/googleapis/python-bigquery-sqlalchemy.git@0a3151b

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ tqdm
 gcsfs
 ipyleaflet
 asyncio
+google-cloud-bigquery-storage
 sqlalchemy~=1.3.0
 git+https://github.com/machow/siuba.git@feat-bigquery
 git+https://github.com/googleapis/python-bigquery-sqlalchemy.git@0a3151b


### PR DESCRIPTION
This notebook adds a widget, so people can select validation results for specific districts. When they select an option, it queries bigquery, downloads to CSV, and provides a link to download the data.

Some things TODO:

* testing locally:  I think I'll need to mount credentials in the docker-compose. ~~Is there a way to use the jupyterlab instance running via docker? It looks like the password is set to empty, but not sure how to log in.~~ (had another jupyter lab running on the same port)
* whitelist file downloads in voila / strategy for where to put downloaded files?
* general cleanup: once I can preview in voila--I can clean up the notebook